### PR TITLE
Add zellij tab status indicator hooks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,11 @@
       "name": "dev-tools",
       "source": "./dev-tools",
       "description": "Development tools: agents for coding, refactoring, and architecture"
+    },
+    {
+      "name": "zellij-claude-status",
+      "source": "./zellij-claude-status",
+      "description": "Zellij tab status indicator — shows Claude session state via icon prefix"
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: update update-marketplace update-plugin reinstall release release-patch release-minor release-major ensure-marketplace list-claude-profiles install-all update-all install-scripts
+.PHONY: update update-marketplace update-plugin deploy reinstall release release-patch release-minor release-major ensure-marketplace list-claude-profiles install-all update-all install-scripts deploy-zellij
 
 PLUGIN_JSON = dev-tools/.claude-plugin/plugin.json
 MARKETPLACE_PATH = $(shell pwd)
@@ -17,6 +17,16 @@ update-marketplace:
 # Update dev-tools plugin
 update-plugin:
 	claude plugin update dev-tools@dapi
+
+# Deploy dev-tools plugin (reinstall to pick up all changes)
+deploy: reinstall
+	@echo "🚀 Plugin deployed. Restart Claude to apply changes."
+
+# Deploy zellij-claude-status plugin
+deploy-zellij: ensure-marketplace
+	claude plugin uninstall zellij-claude-status@dapi || true
+	claude plugin install zellij-claude-status@dapi
+	@echo "🚀 zellij-claude-status deployed. Restart Claude to apply changes."
 
 # Full reinstall (uninstall + install)
 reinstall: uninstall install

--- a/zellij-claude-status/.claude-plugin/plugin.json
+++ b/zellij-claude-status/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "zellij-claude-status",
+  "description": "Zellij tab status indicator — shows Claude session state via icon prefix in tab name",
+  "version": "1.0.0",
+  "author": {
+    "name": "Danil Pismenny",
+    "email": "danilpismenny@gmail.com"
+  },
+  "homepage": "https://github.com/dapi/claude-code-marketplace",
+  "repository": "https://github.com/dapi/claude-code-marketplace",
+  "license": "MIT",
+  "keywords": ["zellij", "status", "hooks", "tab", "indicator"]
+}

--- a/zellij-claude-status/hooks/hooks.json
+++ b/zellij-claude-status/hooks/hooks.json
@@ -1,0 +1,72 @@
+{
+  "description": "Zellij tab status indicator — shows Claude session state via icon prefix",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-session-start.sh",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-prompt-submit.sh",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-subagent-start.sh",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-subagent-stop.sh",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-permission-prompt.sh",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-stop.sh",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/zellij-claude-status/hooks/on-permission-prompt.sh
+++ b/zellij-claude-status/hooks/on-permission-prompt.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(dirname "$0")/zellij-status.sh" needs-input

--- a/zellij-claude-status/hooks/on-prompt-submit.sh
+++ b/zellij-claude-status/hooks/on-prompt-submit.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(dirname "$0")/zellij-status.sh" working

--- a/zellij-claude-status/hooks/on-session-start.sh
+++ b/zellij-claude-status/hooks/on-session-start.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+"$(dirname "$0")/zellij-agents.sh" reset
+exec "$(dirname "$0")/zellij-status.sh" init

--- a/zellij-claude-status/hooks/on-stop.sh
+++ b/zellij-claude-status/hooks/on-stop.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(dirname "$0")/zellij-status.sh" ready

--- a/zellij-claude-status/hooks/on-subagent-start.sh
+++ b/zellij-claude-status/hooks/on-subagent-start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(dirname "$0")/zellij-agents.sh" start

--- a/zellij-claude-status/hooks/on-subagent-stop.sh
+++ b/zellij-claude-status/hooks/on-subagent-stop.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(dirname "$0")/zellij-agents.sh" stop

--- a/zellij-claude-status/hooks/zellij-agents.sh
+++ b/zellij-claude-status/hooks/zellij-agents.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Manages agent counter in zellij session name.
+# Usage: zellij-agents.sh <start|stop|reset>
+
+set -euo pipefail
+
+[ -n "${ZELLIJ_SESSION_NAME:-}" ] || exit 0
+
+ACTION="${1:-}"
+COUNTER_FILE="/tmp/zellij-claude-agents-${ZELLIJ_SESSION_NAME}"
+LOCK_FILE="${COUNTER_FILE}.lock"
+SESSION_CACHE="/tmp/zellij-claude-session-${ZELLIJ_SESSION_NAME}"
+
+# Cache original session name on first use
+if [ ! -f "$SESSION_CACHE" ]; then
+  ORIG=$(echo "$ZELLIJ_SESSION_NAME" | sed -E 's/ \([0-9]+\)$//')
+  echo "$ORIG" > "$SESSION_CACHE"
+fi
+
+ORIGINAL_SESSION=$(cat "$SESSION_CACHE")
+
+# Atomic counter update with flock
+(
+  flock 9
+  COUNT=0
+  [ -f "$COUNTER_FILE" ] && COUNT=$(cat "$COUNTER_FILE")
+
+  case "$ACTION" in
+    start) COUNT=$((COUNT + 1)) ;;
+    stop)  COUNT=$((COUNT > 0 ? COUNT - 1 : 0)) ;;
+    reset) COUNT=0 ;;
+    *)     exit 0 ;;
+  esac
+
+  echo "$COUNT" > "$COUNTER_FILE"
+) 9>"$LOCK_FILE"
+
+# Rename session outside flock (zellij needs pipe on stdin)
+COUNT=$(cat "$COUNTER_FILE")
+if [ "$COUNT" -gt 0 ]; then
+  echo | zellij action rename-session "${ORIGINAL_SESSION} (${COUNT})"
+else
+  echo | zellij action rename-session "${ORIGINAL_SESSION}"
+fi

--- a/zellij-claude-status/hooks/zellij-status.sh
+++ b/zellij-claude-status/hooks/zellij-status.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Manages icon prefix in zellij tab name to reflect Claude session state.
+# Usage: zellij-status.sh <state>
+# States: working, needs-input, ready, init
+
+set -euo pipefail
+
+# Skip if not inside zellij
+[ -n "${ZELLIJ_SESSION_NAME:-}" ] || exit 0
+
+STATE="${1:-}"
+CACHE_FILE="/tmp/zellij-claude-tab-${ZELLIJ_SESSION_NAME}-${ZELLIJ_PANE_ID}"
+
+# "init" is called from SessionStart — the only moment we can trust focus=true
+if [ "$STATE" = "init" ]; then
+  ORIGINAL_NAME=$(zellij action dump-layout 2>/dev/null \
+    | grep -P 'tab name=.*focus=true' \
+    | head -1 \
+    | sed 's/.*name="\([^"]*\)".*/\1/')
+
+  # Strip any existing icon prefixes
+  while echo "$ORIGINAL_NAME" | grep -qE '^(🤖|✋|❓|🟢|🔄|⏳) '; do
+    ORIGINAL_NAME=$(echo "$ORIGINAL_NAME" | sed -E 's/^(🤖|✋|❓|🟢|🔄|⏳) //')
+  done
+
+  [ -n "$ORIGINAL_NAME" ] || exit 0
+  echo "$ORIGINAL_NAME" > "$CACHE_FILE"
+  zellij action rename-tab "🟢 ${ORIGINAL_NAME}"
+  exit 0
+fi
+
+case "$STATE" in
+  working)      ICON="🤖" ;;
+  needs-input)  ICON="✋" ;;
+  ready)        ICON="🟢" ;;
+  *)            exit 0 ;;
+esac
+
+# No cache = SessionStart hasn't run yet, skip silently
+[ -f "$CACHE_FILE" ] || exit 0
+
+ORIGINAL_NAME=$(cat "$CACHE_FILE")
+zellij action rename-tab "${ICON} ${ORIGINAL_NAME}"


### PR DESCRIPTION
## Summary

- New standalone plugin `zellij-claude-status` — signals Claude session state via icon prefix in zellij tab name (🟢 Ready, 🤖 Working, ✋ Needs input)
- Tracks active subagent count in zellij session name
- Add `make deploy-zellij` target for plugin deployment
- Register plugin in marketplace.json

## Files

- `zellij-claude-status/.claude-plugin/plugin.json` — plugin metadata
- `zellij-claude-status/hooks/hooks.json` — hook configuration
- `zellij-claude-status/hooks/zellij-status.sh` — main script managing tab icon prefix
- `zellij-claude-status/hooks/zellij-agents.sh` — atomic counter for active subagents
- `zellij-claude-status/hooks/on-*.sh` — wrapper scripts for each Claude hook event

Closes #7

## Test plan

- [ ] `make deploy-zellij` installs plugin
- [ ] Start Claude in zellij — tab shows 🟢 prefix
- [ ] Submit a prompt — tab switches to 🤖
- [ ] Permission prompt — tab switches to ✋
- [ ] Claude finishes — tab returns to 🟢
- [ ] Subagent count appears in session name during parallel agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)