### PR TITLE
Replace emoji lint with surrogate codepoint lint

### DIFF
--- a/.github/workflows/skill-quality-check.yml
+++ b/.github/workflows/skill-quality-check.yml
@@ -27,14 +27,14 @@ jobs:
           fetch-depth: 0  # Full history for accurate diff
 
       - name: Make scripts executable
-        run: chmod +x scripts/review_skill_triggers.sh scripts/lint_no_emoji.sh
+        run: chmod +x scripts/review_skill_triggers.sh scripts/lint_no_surrogates.sh
 
-      - name: Lint encoding (no supplementary plane emoji)
-        id: emoji-lint
+      - name: Lint shell scripts (no surrogate codepoints)
+        id: surrogate-lint
         run: |
-          ./scripts/lint_no_emoji.sh || {
+          ./scripts/lint_no_surrogates.sh || {
             echo "status=failed" >> $GITHUB_OUTPUT
-            echo "::error::Supplementary plane characters (emoji U+10000+) found in plugin files. Run: ./scripts/lint_no_emoji.sh --fix"
+            echo "::error::Shell scripts contain invalid UTF-8 or surrogate codepoints. See output above."
             exit 1
           }
           echo "status=passed" >> $GITHUB_OUTPUT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,23 +536,17 @@ git commit -m "Fix skill triggers: expand verb diversity (78/100 → 88/100)"
 - Skill descriptions must explicitly state activation criteria
 - Include concrete examples, not vague generalizations
 
-### Encoding Safety (NO EMOJI in plugin files)
+### Bash Output Safety (Unicode)
 
-**CRITICAL**: Plugin files (.md, .json) must NOT contain supplementary plane Unicode characters (U+10000+). This includes all emoji like `U+1F680` etc. These characters require UTF-16 surrogate pairs and cause `"no low surrogate in string"` API errors when Claude Code serializes large payloads.
+Claude Code has a known bug ([#16294](https://github.com/anthropics/claude-code/issues/16294)) where **unpaired UTF-16 surrogates** in Bash tool output crash the session with `"no low surrogate in string"` API error. This happens when bash commands output binary data, corrupted text, or certain terminal escape sequences.
 
-**What to use instead:**
-- Categories: `**Bold Headers**` instead of emoji prefixes
-- Status markers: `[YES]`, `[NO]`, `[OK]`, `[FAIL]` instead of checkmarks/crosses
-- Bullets: `- `, `* `, `>` instead of decorative emoji
+**When using Bash tool:**
+- Avoid `cat`-ing binary files or files with unknown encoding
+- Redirect binary output to files instead of capturing in variables
+- Use `2>/dev/null` or `| head` to limit output from tools that may produce binary data (e.g., mutation testing tools like mutmut/Stryker)
+- If a session crashes with surrogate error, start a new session
 
-**Validation:**
-```bash
-make lint-emoji           # Check all plugins
-make lint-emoji-fix       # Auto-remove emoji
-./scripts/lint_no_emoji.sh task-router  # Check single plugin
-```
-
-**CI enforced**: The `skill-quality-check` workflow blocks merge if emoji are found.
+**Emoji in plugin files are fine.** Valid Unicode characters (including supplementary plane emoji like `U+1F680`) are correctly serialized to JSON and do NOT cause surrogate pair errors.
 
 ### JSON Validity
 - All `plugin.json` files must be valid JSON
@@ -596,13 +590,6 @@ make reinstall-plugin PLUGIN=zellij-workflow
 4. Install всех `PLUGINS`
 
 **Суффикс `-all`** означает "для всех Claude-аккаунтов", а не "все плагины".
-
-### Линтинг
-
-```bash
-make lint-emoji       # Проверить на запрещённые emoji
-make lint-emoji-fix   # Авто-удалить emoji
-```
 
 ### Релизы
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
         release release-patch release-minor release-major version \
         install-zellij-tab-status \
         list-claude-profiles \
-        lint lint-emoji lint-emoji-fix \
+        lint \
         remote-update
 
 # ============================================================================
@@ -270,10 +270,7 @@ endif
 # LINT TARGETS
 # ============================================================================
 
-lint: lint-emoji
+lint: lint-surrogates
 
-lint-emoji:
-	@./scripts/lint_no_emoji.sh
-
-lint-emoji-fix:
-	@./scripts/lint_no_emoji.sh --fix
+lint-surrogates:
+	@./scripts/lint_no_surrogates.sh

--- a/scripts/lint_no_surrogates.sh
+++ b/scripts/lint_no_surrogates.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# lint_no_surrogates.sh — Check bash scripts for bytes that could produce unpaired surrogates
+#
+# Claude Code has a known bug (#16294) where unpaired UTF-16 surrogates in
+# tool output crash the session with "no low surrogate in string" API error.
+#
+# Valid UTF-8 files should never contain surrogate codepoints (U+D800-U+DFFF).
+# This script checks all .sh files in plugins for invalid UTF-8 sequences
+# that encode surrogate codepoints.
+#
+# Usage:
+#   ./scripts/lint_no_surrogates.sh              # Check all plugins
+#   ./scripts/lint_no_surrogates.sh plugin-name   # Check one plugin
+#
+# Exit codes:
+#   0 — no issues found
+#   1 — issues found (or error)
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TARGET="${1:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$REPO_DIR"
+
+total_issues=0
+total_files=0
+failed_plugins=0
+
+# Find plugin directories
+for entry in $(ls -d */); do
+  entry="${entry%/}"
+  [[ -f "$entry/.claude-plugin/plugin.json" ]] || continue
+  [[ -z "$TARGET" || "$entry" == "$TARGET" ]] || continue
+
+  plugin_issues=0
+
+  while IFS= read -r -d '' shfile; do
+    total_files=$((total_files + 1))
+
+    # Check for invalid UTF-8 (includes surrogate codepoints)
+    # iconv will fail on invalid UTF-8 sequences
+    if ! iconv -f UTF-8 -t UTF-8 "$shfile" >/dev/null 2>&1; then
+      echo -e "  ${RED}[FAIL]${NC} $shfile — contains invalid UTF-8 (possible surrogate codepoints)"
+      plugin_issues=$((plugin_issues + 1))
+      total_issues=$((total_issues + 1))
+      continue
+    fi
+
+    # Check for literal surrogate codepoints encoded as UTF-8 (3-byte sequences ED A0-BF xx)
+    # U+D800..U+DFFF encoded in UTF-8: ED [A0-BF] [80-BF]
+    if LC_ALL=C grep -Pn $'\\xED[\\xA0-\\xBF][\\x80-\\xBF]' "$shfile" >/dev/null 2>&1; then
+      echo -e "  ${RED}[FAIL]${NC} $shfile — contains UTF-8 encoded surrogate codepoints (U+D800-U+DFFF)"
+      plugin_issues=$((plugin_issues + 1))
+      total_issues=$((total_issues + 1))
+      continue
+    fi
+  done < <(find "$entry" -name '*.sh' -type f -print0)
+
+  if [[ $plugin_issues -gt 0 ]]; then
+    failed_plugins=$((failed_plugins + 1))
+  else
+    echo -e "${GREEN}[OK]${NC}   $entry/"
+  fi
+done
+
+if [[ -n "$TARGET" && $total_files -eq 0 ]]; then
+  echo -e "${RED}Plugin not found: $TARGET${NC}"
+  exit 1
+fi
+
+# Summary
+echo ""
+echo -e "${BLUE}==================================================${NC}"
+echo "Plugins checked: $((failed_plugins + $(ls -d */  2>/dev/null | while read d; do d="${d%/}"; [[ -f "$d/.claude-plugin/plugin.json" ]] && [[ -z "$TARGET" || "$d" == "$TARGET" ]] && echo ok; done | wc -l)))"
+echo "Shell scripts scanned: $total_files"
+
+if [[ $total_issues -eq 0 ]]; then
+  echo -e "${GREEN}No invalid UTF-8 or surrogate codepoints found.${NC}"
+  exit 0
+else
+  echo -e "${RED}Found $total_issues issue(s) in $failed_plugins plugin(s).${NC}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Remove false emoji ban from CI and CLAUDE.md — emoji in plugin files are safe
- Add `lint_no_surrogates.sh` — checks `.sh` files for invalid UTF-8 / surrogate codepoints (the actual Claude Code bug #16294)
- Update CLAUDE.md with "Bash Output Safety" section documenting the real bug

## Context

The emoji ban was based on a misunderstanding. Bug [#16294](https://github.com/anthropics/claude-code/issues/16294) is about **unpaired UTF-16 surrogates** in bash tool output (binary data, corrupted text), NOT about valid supplementary plane emoji in source files. Valid emoji like 🧩 are properly UTF-8 encoded and serialize to JSON without issues.

## Test plan

- [x] `./scripts/lint_no_surrogates.sh` passes on all 13 plugins (17 .sh files scanned)
- [x] All 120 pr-review-fix-loop tests pass
- [x] CI should pass (emoji lint step replaced with surrogate lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)